### PR TITLE
Update watch.js

### DIFF
--- a/tasks/config/watch.js
+++ b/tasks/config/watch.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
 		assets: {
 
 			// Assets to watch:
-			files: ['assets/**/*', 'tasks/pipeline.js', '!**/node_modules/**'],
+			files: ['assets/**/*.js', 'tasks/pipeline.js', '!**/node_modules/**'],
 
 			// When assets are changed:
 			tasks: ['syncAssets' , 'linkAssets'],


### PR DESCRIPTION
I ran into a problem where grunt had a problem watching too many files. This prevented the watch from occurring with grunt.
(I used sails lift --silly to see the grunt error)
 After reading some bug reports it seems specifying the file type can resolve the issue (which it did for me)
